### PR TITLE
Link typo.

### DIFF
--- a/_chapters_en/index.md
+++ b/_chapters_en/index.md
@@ -35,6 +35,6 @@ Questions, suggestions, and corrections are very welcome:
 please file an issue in our [GitHub repository]({{site.repo}})
 or [email the author directly](mailto:{{site.email}}).
 Please note that all contributors are required to abide by
-our code of conduct ((s:joining)[#APPENDIX]).
+our code of conduct ([s:joining](#APPENDIX)).
 
 {% include links.md %}


### PR DESCRIPTION
[] and () switched. I was not able to build to test:

    $ make lang=en bib
    make: *** No rule to make target `tex_en/book.bib', needed by `_chapters_en/bib.md'.  Stop

There might be a rule missing in the makefile